### PR TITLE
Handle more than 1 domain in translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-brainly-i18",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {

--- a/translations/messages-js.json
+++ b/translations/messages-js.json
@@ -4,6 +4,10 @@
       "messages": {
         "Next key": "key Next",
         "Number of stars %stars% and average %average%": "Liczba gwiazdek: %stars% i ich srednia %average%"
+      },
+      "descriptions": {
+        "Next other key": "key other Next",
+        "other Number of stars %stars% and average %average%": "other Liczba gwiazdek: %stars% i ich srednia %average%"
       }
     }
   }

--- a/translations/messages.json
+++ b/translations/messages.json
@@ -4,6 +4,10 @@
       "messages": {
         "Some key": "Some translation",
         "Other key": "Other \"translation\""
+      },
+      "descriptions": {
+        "Some other key": "Some other translation",
+        "Other other key": "Other other \"translation\""
       }
     }
   }

--- a/translator.js
+++ b/translator.js
@@ -4,10 +4,13 @@ module.exports = class Translator {
 
     this.sourceStrings = translations.reduce((strings, trans) => {
       const locale = Object.keys(trans.translations)[0];
-      const domain = Object.keys(trans.translations[locale])[0];
-      const messages = trans.translations[locale][domain];
+      const messagesPerDomain = Object.values(trans.translations[locale]);
+      const translations = Object.values(messagesPerDomain).reduce(
+        (allKeys, domainKeys) => Object.assign(allKeys, domainKeys),
+        {}
+      );
 
-      return Object.assign(strings, messages);
+      return Object.assign(strings, translations);
     }, {});
   }
 


### PR DESCRIPTION
So far it was handling only a first specified "domain". In our case it was a "messages" object.
We had no other use cases earlier, but now we need to handle other "domains" too, i..e. "descriptions".

After this change all keys from "messages" object are merged with other domain keys if there are specified.

<img width="696" alt="Screenshot 2020-06-02 at 12 06 13" src="https://user-images.githubusercontent.com/1231144/83507911-79f98980-a4c9-11ea-8963-deb21337faef.png">
